### PR TITLE
Remove toolchain as it breaks JDK 17

### DIFF
--- a/buildSrc/src/main/kotlin/com.workos.java.examples.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.workos.java.examples.java-common-conventions.gradle.kts
@@ -21,10 +21,3 @@ dependencies {
 tasks.test {
   useJUnitPlatform()
 }
-
-java {
-  toolchain {
-    // Determines JDK version used for compilation. See https://docs.gradle.org/current/userguide/toolchains.html
-    languageVersion.set(JavaLanguageVersion.of(11))
-  }
-}


### PR DESCRIPTION
Not sure as to why this causes issues yet, removing for now to unblock @erin-workos since we can get by without it.